### PR TITLE
[BGF] replace the invalid url inside of the MediaPlayer demo.

### DIFF
--- a/Android/APIExample/app/src/main/java/io/agora/api/example/examples/advanced/MediaPlayer.java
+++ b/Android/APIExample/app/src/main/java/io/agora/api/example/examples/advanced/MediaPlayer.java
@@ -66,7 +66,7 @@ public class MediaPlayer extends BaseFragment implements View.OnClickListener, I
     private SeekBar progressBar;
     private long playerDuration = 0;
 
-    private static final String SAMPLE_MOVIE_URL = "https://mp4.video-call-statics.agora.io/prd%2F26aebb92aa41dc5a0a2f6c880b5ba08c_N9BsDk-H5tw-9bbcb5ab-64dc-45ea-92b8-4bbd02cc2cc1avc.mp4?Expires=1627016601&OSSAccessKeyId=LTAI4GFSLFYRoqnVcUrEjkig&Signature=TiPpNU6zi9aFHXRmY8Z1Ido2FMA%3D";
+    private static final String SAMPLE_MOVIE_URL = "https://webdemo.agora.io/agora-web-showcase/examples/Agora-Custom-VideoSource-Web/assets/sample.mp4";
 
     @Nullable
     @Override

--- a/Android/APIExample/app/src/main/res/layout/fragment_media_player.xml
+++ b/Android/APIExample/app/src/main/res/layout/fragment_media_player.xml
@@ -112,9 +112,9 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
+            android:inputType="text|textUri"
             android:hint="@string/channel_id"
-            android:singleLine="true"
-            android:digits="@string/chanel_support_char"/>
+            android:singleLine="true"/>
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/open"


### PR DESCRIPTION
The old URL is expired, replace a new default one. 
And remove the digits of `EditText` to allow custom URL.