### PR TITLE
[BGF] For MultiProcess.java enable audio&video feature and a crash fixed.

### DIFF
--- a/Android/APIExample/app/src/main/java/io/agora/api/example/examples/advanced/MultiProcess.java
+++ b/Android/APIExample/app/src/main/java/io/agora/api/example/examples/advanced/MultiProcess.java
@@ -192,7 +192,8 @@ public class MultiProcess extends BaseFragment implements View.OnClickListener
                  *          triggers the removeInjectStreamUrl method.*/
                 engine.leaveChannel();
                 join.setText(getString(R.string.join));
-                mSSClient.stop(getContext());
+                if(isSharing)
+                    mSSClient.stop(getContext());
                 screenShare.setText(getResources().getString(R.string.screenshare));
                 screenShare.setEnabled(false);
                 isSharing = false;
@@ -244,9 +245,6 @@ public class MultiProcess extends BaseFragment implements View.OnClickListener
         fl_local.addView(surfaceView, new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
         // Setup local video to render your local camera preview
         engine.setupLocalVideo(new VideoCanvas(surfaceView, RENDER_MODE_HIDDEN, 0));
-        // Set audio route to microPhone
-        engine.disableAudio();
-//        engine.setDefaultAudioRoutetoSpeakerphone(false);
 
         /** Sets the channel profile of the Agora RtcEngine.
          CHANNEL_PROFILE_COMMUNICATION(0): (Default) The Communication profile.
@@ -281,8 +279,8 @@ public class MultiProcess extends BaseFragment implements View.OnClickListener
          if you do not specify the uid, we will generate the uid for you*/
 
         ChannelMediaOptions option = new ChannelMediaOptions();
-        option.autoSubscribeAudio = false;
-        option.autoSubscribeVideo = false;
+        option.autoSubscribeAudio = true;
+        option.autoSubscribeVideo = true;
         int res = engine.joinChannel(accessToken, channelId, "Extra Optional Data", 0, option);
         if (res != 0)
         {

--- a/Android/APIExample/lib-screensharing/src/main/java/io/agora/rtc/ss/ScreenSharingClient.java
+++ b/Android/APIExample/lib-screensharing/src/main/java/io/agora/rtc/ss/ScreenSharingClient.java
@@ -35,7 +35,7 @@ public class ScreenSharingClient {
         return mInstance;
     }
 
-    private ServiceConnection mScreenShareConn = new ServiceConnection() {
+    private final ServiceConnection mScreenShareConn = new ServiceConnection() {
         public void onServiceConnected(ComponentName className, IBinder service) {
             mScreenShareSvc = IScreenSharing.Stub.asInterface(service);
 
@@ -54,7 +54,7 @@ public class ScreenSharingClient {
         }
     };
 
-    private INotification mNotification = new INotification.Stub() {
+    private final INotification mNotification = new INotification.Stub() {
         /**
          * This is called by the remote service to tell us about error happened.
          * Note that IPC calls are dispatched through a thread


### PR DESCRIPTION
1. Somehow Audio & Video stream is disabled by default.
2. When Join channel then Leave channel, do not turn on ScreenShare, the service is not running, but the logic code still tried to stop the service.