### PR TITLE
Dark Mode Fix

### DIFF
--- a/iOS/APIExample/APIExample/Common/NetworkManager/ToastView.swift
+++ b/iOS/APIExample/APIExample/Common/NetworkManager/ToastView.swift
@@ -21,7 +21,11 @@ class ToastView: UIView {
     private lazy var label: UILabel = {
         let label = UILabel()
         label.text = ""
-        label.textColor = .white
+        if #available(iOS 13.0, *) {
+            label.textColor = .label
+        } else {
+            label.textColor = .white
+        }
         label.font = .systemFont(ofSize: 14)
         label.numberOfLines = 0
         label.preferredMaxLayoutWidth = UIScreen.main.bounds.width - 60
@@ -66,9 +70,13 @@ class ToastView: UIView {
     static func showWait(text: String, view: UIView? = nil) {
         DispatchQueue.main.async {
             self.currentToastView?.removeFromSuperview()
+            var textColor: UIColor = .white
+            if #available(iOS 13.0, *) {
+                textColor = .label
+            }
             let toastView = show(text: text,
                                  tagImage: nil,
-                                 textColor: .white,
+                                 textColor: textColor,
                                  font: nil,
                                  postion: .center,
                                  view: view)
@@ -92,8 +100,12 @@ class ToastView: UIView {
     
     static func show(text: String, duration: CGFloat = 2.5, view: UIView? = nil) {
         DispatchQueue.main.async {
+            var textColor: UIColor = .white
+            if #available(iOS 13.0, *) {
+                textColor = .label
+            }
             let toastView = show(text: text, tagImage: nil,
-                                 textColor: .white, font: nil,
+                                 textColor: textColor, font: nil,
                                  postion: .center,
                                  view: view)
             showAnimation(toastView: toastView, duration: duration)
@@ -102,8 +114,12 @@ class ToastView: UIView {
     
     static func show(text: String, postion: ToastViewPostion = .center) {
         DispatchQueue.main.async {
+            var textColor: UIColor = .white
+            if #available(iOS 13.0, *) {
+                textColor = .label
+            }
             let toastView = show(text: text, tagImage: nil,
-                                 textColor: .white, font: nil,
+                                 textColor: textColor, font: nil,
                                  postion: postion,
                                  view: nil)
             showAnimation(toastView: toastView)
@@ -115,8 +131,12 @@ class ToastView: UIView {
                      duration: CGFloat = 2.5,
                      view: UIView? = nil) {
         DispatchQueue.main.async {
+            var textColor: UIColor = .white
+            if #available(iOS 13.0, *) {
+                textColor = .label
+            }
             let toastView = show(text: text, tagImage: nil,
-                                 textColor: .white, font: nil,
+                                 textColor: textColor, font: nil,
                                  postion: postion,
                                  view: view)
             showAnimation(toastView: toastView, duration: duration)
@@ -125,8 +145,12 @@ class ToastView: UIView {
     
     static func show(text: String, tagImage: UIImage? = nil, postion: ToastViewPostion = .center, view: UIView? = nil) {
         DispatchQueue.main.async {
+            var textColor: UIColor = .white
+            if #available(iOS 13.0, *) {
+                textColor = .label
+            }
             let toastView = show(text: text, tagImage: tagImage,
-                                 textColor: .white, font: nil,
+                                 textColor: textColor, font: nil,
                                  postion: postion,
                                  view: view)
             

--- a/iOS/APIExample/APIExample/Examples/Advanced/SpatialAudio/SpatialAudio.swift
+++ b/iOS/APIExample/APIExample/Examples/Advanced/SpatialAudio/SpatialAudio.swift
@@ -322,7 +322,7 @@ class SpatialAudioActionSheet: UIView {
     }()
     private lazy var attenuationLabel: UILabel = {
         let label = UILabel()
-        label.text = "Attenuatuin".localized
+        label.text = "Attenuation".localized
         return label
     }()
     private lazy var muteSwitch: UISwitch = {

--- a/iOS/APIExample/APIExample/Examples/Advanced/SpatialAudio/SpatialAudio.swift
+++ b/iOS/APIExample/APIExample/Examples/Advanced/SpatialAudio/SpatialAudio.swift
@@ -356,7 +356,11 @@ class SpatialAudioActionSheet: UIView {
     }
     
     private func setupUI() {
-        backgroundColor = .white
+        if #available(iOS 13.0, *) {
+            backgroundColor = .tertiarySystemBackground
+        } else {
+            backgroundColor = .white
+        }
         addSubview(muteLabel)
         addSubview(voiceBlurLabel)
         addSubview(airborneLabel)


### PR DESCRIPTION
Some backgrounds hard-set to appear in `.white` when in dark mode, but text also appearing as white. Meaning the white text cannot be read.

| Before | After |
|--------|------|
| ![IMG_7705](https://user-images.githubusercontent.com/5754073/222095222-af298a08-14ca-46cd-85a9-5df675303fa3.PNG) | ![IMG_7706](https://user-images.githubusercontent.com/5754073/222095210-bf07514e-317b-4e6f-9a5d-02f1e4eb0983.PNG) |
