### PR TITLE
Change way of using salt

### DIFF
--- a/Android/APIExample/app/src/main/java/io/agora/api/example/examples/advanced/ChannelEncryption.java
+++ b/Android/APIExample/app/src/main/java/io/agora/api/example/examples/advanced/ChannelEncryption.java
@@ -9,6 +9,7 @@ import static io.agora.rtc2.video.VideoEncoderConfiguration.VD_640x360;
 
 import android.content.Context;
 import android.os.Bundle;
+import android.util.Base64;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.SurfaceView;
@@ -28,7 +29,6 @@ import com.yanzhenjie.permission.AndPermission;
 import com.yanzhenjie.permission.runtime.Permission;
 
 import java.lang.reflect.Method;
-import java.nio.charset.StandardCharsets;
 
 import io.agora.api.example.MainApplication;
 import io.agora.api.example.R;
@@ -255,7 +255,10 @@ public class ChannelEncryption extends BaseFragment implements View.OnClickListe
     }
 
     private byte[] getKdfSaltFromServer() {
-        return "EncryptionKdfSaltInBase64Strings".getBytes(StandardCharsets.UTF_8);
+        // Salt string should be the output of the following command:
+        // openssl rand -base64 32
+        String saltBase64String = "NiIeJ08AbtcQVjvV+oOEvF/4Dz5dy1CIwa805C8J2w0=";
+        return Base64.decode(saltBase64String, Base64.DEFAULT);
     }
 
     private void joinChannel(String channelId) {

--- a/iOS/APIExample-OC/APIExample-OC/Examples/Advanced/StreamEncryption/StreamEncryption.m
+++ b/iOS/APIExample-OC/APIExample-OC/Examples/Advanced/StreamEncryption/StreamEncryption.m
@@ -127,10 +127,14 @@
         [AgoraCustomEncryption registerPacketProcessing:self.agoraKit];
         
     } else {
+        // Salt string should be the output of the following command:
+        // openssl rand -base64 32
+        NSString *saltBase64String = @"NiIeJ08AbtcQVjvV+oOEvF/4Dz5dy1CIwa805C8J2w0=";
+        
         AgoraEncryptionConfig *config = [[AgoraEncryptionConfig alloc] init];
         config.encryptionMode = mode;
         config.encryptionKey = secret;
-        config.encryptionKdfSalt = [@"EncryptionKdfSaltInBase64Strings" dataUsingEncoding:(kCFStringEncodingUTF8)];
+        config.encryptionKdfSalt = [[NSData alloc] initWithBase64EncodedString:(saltBase64String) options:(0)];
        int ret = [self.agoraKit enableEncryption:YES encryptionConfig:config];
         if (ret != 0) {
             // for errors please take a look at:

--- a/iOS/APIExample/APIExample/Examples/Advanced/StreamEncryption/StreamEncryption.swift
+++ b/iOS/APIExample/APIExample/Examples/Advanced/StreamEncryption/StreamEncryption.swift
@@ -184,7 +184,10 @@ class StreamEncryptionMain: BaseViewController {
     }
     
     func getEncryptionSaltFromServer() -> Data {
-        return "EncryptionKdfSaltInBase64Strings".data(using: .utf8) ?? Data()
+        // Salt string should be the output of the following command:
+        // openssl rand -base64 32
+        let saltBase64String = "NiIeJ08AbtcQVjvV+oOEvF/4Dz5dy1CIwa805C8J2w0="
+        return Data(base64Encoded: saltBase64String.data(using: .utf8)!)!
     }
 
     override func willMove(toParent parent: UIViewController?) {

--- a/macOS/APIExample/Examples/Advanced/StreamEncryption/StreamEncryption.swift
+++ b/macOS/APIExample/Examples/Advanced/StreamEncryption/StreamEncryption.swift
@@ -315,8 +315,10 @@ class StreamEncryption: BaseViewController {
     }
     
     func getEncryptionSaltFromServer() -> Data {
-
-        return "EncryptionKdfSaltInBase64Strings".data(using: .utf8)!
+        // Salt string should be the output of the following command:
+        // openssl rand -base64 32
+        let saltBase64String = "NiIeJ08AbtcQVjvV+oOEvF/4Dz5dy1CIwa805C8J2w0="
+        return Data(base64Encoded: saltBase64String.data(using: .utf8)!)!
     }
     
     func layoutVideos(_ count: Int) {


### PR DESCRIPTION
SDK 要求 salt 为 length 为 32  的 byte array，目前文档里推荐用户使用 openssl 生成

之前 Demo 里直接使用 UTF-8 String 的方式会导致用户根据文档使用时，只替换字符串无法正常加解密