### PR TITLE
Modernize Compose API example project

### DIFF
--- a/Android/APIExample-Compose/app/build.gradle.kts
+++ b/Android/APIExample-Compose/app/build.gradle.kts
@@ -1,11 +1,12 @@
-import com.android.build.gradle.internal.api.ApkVariantOutputImpl
+
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Properties
 
 plugins {
     alias(libs.plugins.androidApplication)
-    alias(libs.plugins.jetbrainsKotlinAndroid)
+    alias(libs.plugins.kotlinCompose)
 }
 
 val sdkVersionFile = file("../gradle.properties")
@@ -17,12 +18,12 @@ val localSdkPath = "${rootProject.projectDir.absolutePath}/../../sdk"
 
 android {
     namespace = "io.agora.api.example.compose"
-    compileSdk = 35
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "io.agora.api.example.compose"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = 37
         versionCode = 1
         versionName = "1.0"
 
@@ -62,6 +63,7 @@ android {
         }
         release {
             isMinifyEnabled = true
+            isShrinkResources = true
             signingConfig = signingConfigs.getByName("myConfig")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -73,41 +75,45 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
-    }
+
     packaging {
+        jniLibs {
+            pickFirsts += "**/libaosl.so"
+            pickFirsts += "**/libc++_shared.so"
+        }
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
-    android.applicationVariants.all {
-        outputs.all {
-            if (this is ApkVariantOutputImpl) {
-                this.outputFileName =
-                    "${rootProject.name}_${agoraSdkVersion}_${
-                        SimpleDateFormat("yyyyMMddHHmm").format(
-                            Date()
-                        )
-                    }.apk"
-            }
-        }
-    }
+}
+base {
+    archivesName.set(
+        "${rootProject.name}_${agoraSdkVersion}_${
+            SimpleDateFormat("yyyyMMddHHmm").format(
+                Date()
+            )
+        }"
+    )
+}
+
+android {
     sourceSets {
         getByName("main") {
             if (File(localSdkPath).exists()) {
-                jniLibs.srcDirs(localSdkPath)
+                jniLibs.directories.add(localSdkPath)
             }
         }
-
+    }
+}
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 
 dependencies {
     implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))

--- a/Android/APIExample-Compose/app/src/androidTest/java/io/agora/api/example/compose/ExampleInstrumentedTest.kt
+++ b/Android/APIExample-Compose/app/src/androidTest/java/io/agora/api/example/compose/ExampleInstrumentedTest.kt
@@ -1,22 +1,27 @@
 package io.agora.api.example.compose
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import androidx.test.platform.app.InstrumentationRegistry
-import org.junit.Assert.assertEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import org.junit.Rule
 import org.junit.Test
-import org.junit.runner.RunWith
 
-/**
- * Instrumented test, which will execute on an Android device.
- *
- * See [testing documentation](http://d.android.com/tools/testing).
- */
-@RunWith(AndroidJUnit4::class)
 class ExampleInstrumentedTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<MainActivity>()
+
     @Test
-    fun useAppContext() {
-        // Context of the app under test.
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("io.agora.api.example.compose", appContext.packageName)
+    fun homeAndSettingsNavigation_renderExpectedContent() {
+        composeRule.onNodeWithText("Agora API Example").assertIsDisplayed()
+        composeRule.onNodeWithText("Basic").assertIsDisplayed()
+        composeRule.onNodeWithText("Join Video Channel").assertIsDisplayed()
+
+        composeRule.onNodeWithContentDescription("Open settings").performClick()
+
+        composeRule.onNodeWithText("Settings").assertIsDisplayed()
+        composeRule.onNodeWithContentDescription("Navigate back").performClick()
+        composeRule.onNodeWithText("Agora API Example").assertIsDisplayed()
     }
 }

--- a/Android/APIExample-Compose/app/src/main/AndroidManifest.xml
+++ b/Android/APIExample-Compose/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
@@ -30,6 +34,7 @@
             android:theme="@style/Theme.APIExampleCompose"
             android:supportsPictureInPicture="true"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
             android:configChanges="screenSize|screenLayout|orientation|smallestScreenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -37,15 +42,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-
-        <!--
-        <activity
-            android:name=".samples.PictureInPictureActivity"
-            android:supportsPictureInPicture="true"
-            android:launchMode="singleTask"
-            android:configChanges="screenSize|screenLayout|orientation|smallestScreenSize"/>
-        -->
-
 </application>
 
 </manifest>

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/ChannelEncryption.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/ChannelEncryption.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/CustomAudioRender.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/CustomAudioRender.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import io.agora.api.example.compose.utils.AgoraConfig

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/CustomAudioSource.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/CustomAudioSource.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/CustomVideoRender.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/CustomVideoRender.kt
@@ -20,7 +20,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import io.agora.api.example.compose.utils.AgoraConfig
 import io.agora.api.example.compose.R

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/CustomVideoSource.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/CustomVideoSource.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import io.agora.api.example.compose.utils.AgoraConfig
 import io.agora.api.example.compose.R

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/HostAcrossChannel.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/HostAcrossChannel.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/JoinChannelAudio.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/JoinChannelAudio.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/JoinChannelVideo.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/JoinChannelVideo.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/JoinChannelVideoToken.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/JoinChannelVideoToken.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/JoinMultiChannel.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/JoinMultiChannel.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import io.agora.api.example.compose.utils.AgoraConfig

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/LiveStreaming.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/LiveStreaming.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -28,7 +28,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -445,7 +445,7 @@ private fun LiveStreamingSettingView(
                 onValueChanged("videoScenario", option.second)
             }
         )
-        Divider(modifier = Modifier.padding(horizontal = 16.dp))
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
         if (role == Constants.CLIENT_ROLE_AUDIENCE) {
             SwitchRaw(
                 title = stringResource(id = R.string.open_low_latency_live),
@@ -460,7 +460,7 @@ private fun LiveStreamingSettingView(
         }
 
         if (role == Constants.CLIENT_ROLE_BROADCASTER) {
-            Divider(modifier = Modifier.padding(horizontal = 16.dp))
+            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
             SwitchRaw(
                 title = stringResource(id = R.string.watermark),
                 checked = values["watermark"] as? Boolean ?: false
@@ -481,7 +481,7 @@ private fun LiveStreamingSettingView(
         }
 
 
-        Divider(modifier = Modifier.padding(horizontal = 16.dp))
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
         SwitchRaw(
             title = stringResource(id = R.string.low_stream),
             checked = values["stream"] as? Boolean ?: false
@@ -497,7 +497,7 @@ private fun LiveStreamingSettingView(
         }
 
 
-        Divider(modifier = Modifier.padding(horizontal = 16.dp))
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
         DropdownMenuRaw(
             title = stringResource(id = R.string.encoder_type),
             options = listOf(
@@ -516,7 +516,7 @@ private fun LiveStreamingSettingView(
             })
         }
 
-        Divider(modifier = Modifier.padding(horizontal = 16.dp))
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
         SwitchRaw(
             title = stringResource(id = R.string.b_frame),
             checked = values["BFrame"] as? Boolean ?: false
@@ -535,7 +535,7 @@ private fun LiveStreamingSettingView(
         }
 
 
-        Divider(modifier = Modifier.padding(horizontal = 16.dp))
+        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
         SwitchRaw(
             title = stringResource(id = R.string.video_image),
             checked = values["padding"] as? Boolean ?: false

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/LocalVideoTranscoding.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/LocalVideoTranscoding.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/MediaMetadata.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/MediaMetadata.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import io.agora.api.example.compose.utils.AgoraConfig

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/MediaPlayer.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/MediaPlayer.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/MediaRecorder.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/MediaRecorder.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/OriginAudioData.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/OriginAudioData.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/OriginVideoData.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/OriginVideoData.kt
@@ -29,7 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/PictureInPicture.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/PictureInPicture.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -36,7 +35,7 @@ import androidx.compose.ui.graphics.toAndroidRectF
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -64,9 +63,7 @@ private val globalLocalUid = mutableIntStateOf(0)
 private val globalRemoteUid = mutableIntStateOf(0)
 private val globalChannelName = mutableStateOf("")
 private val globalIsJoined = mutableStateOf(false)
-private val isInPipTransition = mutableStateOf(false)
 private val isPageLeaving = mutableStateOf(false) // Flag to track if user is truly leaving the page
-private var globalCleanupFunction: (() -> Unit)? = null // Global cleanup function
 
 // Helper function to find Activity from Context
 private fun Context.findActivity(): ComponentActivity {
@@ -100,7 +97,7 @@ private fun rememberIsInPipMode(): Boolean {
 // Public function to clean up global state when user leaves the page
 fun cleanupPictureInPictureState() {
     Log.d("PiPDebug", "cleanupPictureInPictureState called")
-    globalCleanupFunction?.invoke()
+    isPageLeaving.value = true
 }
 
 @Composable
@@ -111,28 +108,9 @@ fun PictureInPicture() {
 
     Log.d("PiPDebug", "PictureInPicture: Current isPipOn = $isPipOn")
 
-    // Function to mark that user is leaving the page
-    fun markPageLeaving() {
-        isPageLeaving.value = true
-        Log.d("PiPDebug", "Marked page as leaving - global state will be cleared on next dispose")
-    }
-
-    // Register cleanup function globally
-    LaunchedEffect(Unit) {
-        globalCleanupFunction = { markPageLeaving() }
-    }
-
-    // Add LaunchedEffect to handle PiP mode changes
-    LaunchedEffect(isPipOn) {
-        Log.d("PiPDebug", "PiP mode changed to: $isPipOn")
-        // Mark that we're in a PiP transition
-        isInPipTransition.value = true
-        // Note: We can't access localUid and rtcEngine here as they're defined later
-        // The video setup will be handled in the render callbacks
-    }
-
     // Add DisposableEffect to track lifecycle
-    DisposableEffect(Unit) {
+    DisposableEffect(isPipOn) {
+        Log.d("PiPDebug", "PiP mode changed to: $isPipOn")
         onDispose {
             // Only clear global state when user is truly leaving the page (not during PiP transitions)
             if (isPageLeaving.value) {
@@ -250,14 +228,18 @@ fun PictureInPicture() {
             enableVideo()
         }
     }
-    LaunchedEffect(lifecycleOwner) {
-        lifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+    DisposableEffect(lifecycleOwner) {
+        val observer = object : DefaultLifecycleObserver {
             override fun onDestroy(owner: LifecycleOwner) {
                 rtcEngine.stopPreview()
                 rtcEngine.leaveChannel()
                 RtcEngine.destroy()
             }
-        })
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
     }
     val permissionLauncher =
         rememberLauncherForActivityResult(contract = ActivityResultContracts.RequestMultiplePermissions()) { grantedMap ->
@@ -269,7 +251,7 @@ fun PictureInPicture() {
                 mediaOptions.channelProfile = Constants.CHANNEL_PROFILE_LIVE_BROADCASTING
                 mediaOptions.clientRoleType = Constants.CLIENT_ROLE_BROADCASTER
                 mediaOptions.autoSubscribeAudio = true
-                mediaOptions.autoSubscribeAudio = true
+                mediaOptions.autoSubscribeVideo = true
                 mediaOptions.publishCameraTrack = true
                 mediaOptions.publishMicrophoneTrack = true
                 TokenUtils.gen(channelName, 0) {

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/PlayAudioFiles.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/PlayAudioFiles.kt
@@ -24,7 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/PreCallTest.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/PreCallTest.kt
@@ -30,7 +30,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/RTMPStreaming.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/RTMPStreaming.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/RhythmPlayer.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/RhythmPlayer.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/ScreenSharing.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/ScreenSharing.kt
@@ -26,7 +26,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/SendDataStream.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/SendDataStream.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import io.agora.api.example.compose.utils.AgoraConfig
 import io.agora.api.example.compose.R

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/SpatialSound.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/SpatialSound.kt
@@ -42,7 +42,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/VideoProcessExtension.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/VideoProcessExtension.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/VoiceEffects.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/samples/VoiceEffects.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/ui/common/APIExampleTopAppBar.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/ui/common/APIExampleTopAppBar.kt
@@ -14,7 +14,9 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import io.agora.api.example.compose.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -41,7 +43,7 @@ fun APIExampleTopAppBar(
                         IconButton(onClick = { onSettingClick() }) {
                             Icon(
                                 imageVector = Icons.Default.Settings,
-                                contentDescription = ""
+                                contentDescription = stringResource(R.string.settings_action)
                             )
                         }
                     }
@@ -53,7 +55,7 @@ fun APIExampleTopAppBar(
                 IconButton(onClick = onBackClick) {
                     Icon(
                         imageVector = Icons.AutoMirrored.Default.ArrowBack,
-                        contentDescription = ""
+                        contentDescription = stringResource(R.string.navigate_back)
                     )
                 }
             }

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/ui/common/Widgets.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/ui/common/Widgets.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Switch
@@ -344,7 +345,7 @@ fun <T> DropdownMenuRaw(
         ) {
             TextField(
                 // The `menuAnchor` modifier must be passed to the text field for correctness.
-                modifier = Modifier.menuAnchor(),
+                modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryNotEditable, enabled = enable),
                 shape = TextFieldDefaults.shape,
                 value = text,
                 onValueChange = {},
@@ -644,4 +645,3 @@ fun WidgetsPreview() {
         // SliderRaw("Bitrate", 0.5f)
     }
 }
-

--- a/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/ui/settings/Settings.kt
+++ b/Android/APIExample-Compose/app/src/main/java/io/agora/api/example/compose/ui/settings/Settings.kt
@@ -12,7 +12,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -79,7 +79,7 @@ fun Settings(onBackClick: () -> Unit) {
                 ) { _, option ->
                     SettingPreferences.setVideoDimensions(option.second)
                 }
-                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
                 val frameRates = listOf(
                     VideoEncoderConfiguration.FRAME_RATE.FRAME_RATE_FPS_1,
@@ -97,7 +97,7 @@ fun Settings(onBackClick: () -> Unit) {
                 ) { _, option ->
                     SettingPreferences.setVideoFrameRate(option.second)
                 }
-                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
                 val orientationMode = listOf(
                     VideoEncoderConfiguration.ORIENTATION_MODE.ORIENTATION_MODE_ADAPTIVE,
@@ -112,7 +112,7 @@ fun Settings(onBackClick: () -> Unit) {
                     SettingPreferences.setOrientationMode(option.second)
                 }
 
-                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
                 DropdownMenuRaw(
                     title = stringResource(id = R.string.area),
@@ -130,7 +130,7 @@ fun Settings(onBackClick: () -> Unit) {
                     SettingPreferences.setArea(option.second)
                 }
 
-                Divider(modifier = Modifier.padding(horizontal = 16.dp))
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
 
                 Spacer(Modifier.height(16.dp))
                 Text(

--- a/Android/APIExample-Compose/app/src/main/res/values/strings.xml
+++ b/Android/APIExample-Compose/app/src/main/res/values/strings.xml
@@ -98,6 +98,8 @@
     <string name="channel_name">Channel Name</string>
     <string name="leave">Leave</string>
     <string name="settings">Settings</string>
+    <string name="settings_action">Open settings</string>
+    <string name="navigate_back">Navigate back</string>
     <string name="resolution">Resolution</string>
     <string name="frame_rate">Frame Rate</string>
     <string name="orientation">Orientation</string>

--- a/Android/APIExample-Compose/build.gradle.kts
+++ b/Android/APIExample-Compose/build.gradle.kts
@@ -1,5 +1,5 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.androidApplication) apply false
-    alias(libs.plugins.jetbrainsKotlinAndroid) apply false
+    alias(libs.plugins.kotlinCompose) apply false
 }

--- a/Android/APIExample-Compose/gradle.properties
+++ b/Android/APIExample-Compose/gradle.properties
@@ -1,25 +1,10 @@
 # Project-wide Gradle settings.
-# IDE (e.g. Android Studio) users:
-# Gradle settings configured through the IDE *will override*
-# any settings specified in this file.
-# For more details on how to configure your build environment visit
-# http://www.gradle.org/docs/current/userguide/build_environment.html
-# Specifies the JVM arguments used for the daemon process.
-# The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. For more details, visit
-# https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
-# org.gradle.parallel=true
-# AndroidX package structure to make it clearer which packages are bundled with the
-# Android operating system, and which are packaged with your app's APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-# Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
-# Enables namespacing of each library's R class so that its R class includes only the
-# resources declared in the library itself and none from the library's dependencies,
-# thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-
-rtc_sdk_version = 4.6.3
+# Agora RTC 4.6.3 publishes multiple Maven AARs with the same namespace (io.agora.rtc).
+# AGP 9 treats that as a manifest error by default; keep it as a warning until Agora
+# publishes split artifacts with unique namespaces.
+android.uniquePackageNames=false
+rtc_sdk_version=4.6.3

--- a/Android/APIExample-Compose/gradle/libs.versions.toml
+++ b/Android/APIExample-Compose/gradle/libs.versions.toml
@@ -1,20 +1,19 @@
 [versions]
-agp = "8.7.3"
-datastore = "1.1.1"
-kotlin = "1.9.24"
-coreKtx = "1.13.1"
+agp = "9.1.0"
+datastore = "1.2.1"
+kotlin = "2.2.10"
+coreKtx = "1.19.0"
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-espressoContrib = "3.6.1"
-testRunner = "1.6.2"
-lifecycleRuntimeKtx = "2.8.7"
-activityCompose = "1.9.3"
-composeBom = "2024.12.01"
-loggingInterceptor = "4.12.0"
-materialIconsExtended = "1.7.6"
-navigationCompose = "2.8.5"
-okhttp = "4.12.0"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
+espressoContrib = "3.7.0"
+testRunner = "1.7.0"
+lifecycle = "2.11.0"
+activityCompose = "1.13.0"
+composeBom = "2026.06.01"
+materialIconsExtended = "1.7.8"
+navigationCompose = "2.9.8"
+okhttp = "5.4.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,7 +23,8 @@ androidx-material-icons-extended = { module = "androidx.compose.material:materia
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
-androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
@@ -35,10 +35,9 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }
+logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
-jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-
+kotlinCompose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/Android/APIExample-Compose/gradle/wrapper/gradle-wrapper.properties
+++ b/Android/APIExample-Compose/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed Apr 10 23:59:46 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- Update the Compose API example project to the current Android/Kotlin/Compose toolchain.
- Add edge-to-edge/IME handling, app bar accessibility labels, and a Compose navigation smoke test.
- Replace deprecated Compose lifecycle imports and Material divider usage, and clean up PiP lifecycle state handling.
- Add an AGP 9 workaround for Agora RTC 4.6.3 split AARs sharing the `io.agora.rtc` namespace.

## Validation
- `./gradlew assembleDebug`
- `./gradlew test`

## Notes
- Agora RTC 4.6.3 still emits a duplicate namespace warning under AGP 9. The build keeps `android.uniquePackageNames=false` until Agora publishes split artifacts with unique namespaces.